### PR TITLE
Workaround

### DIFF
--- a/app_resize_while_render/ViewModels/MainWindowViewModel.cs
+++ b/app_resize_while_render/ViewModels/MainWindowViewModel.cs
@@ -3,35 +3,60 @@ using System.Collections.Generic;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using ReactiveUI;
 using SkiaSharp;
 
 namespace app_resize_while_render.ViewModels
 {
     public class MainWindowViewModel : ViewModelBase
     {
+        public MainWindowViewModel()
+        {
+            DispatcherTimer timer = new DispatcherTimer(TimeSpan.FromMilliseconds(10), DispatcherPriority.Render, OnTick);
+            timer.Start();
+        }
+
+        private async void OnTick(object? sender, EventArgs e)
+        {
+            await LoadNewImageAsync();
+        }
+
         private SKBitmap _mySkBitmap = SKBitmap.Decode(System.IO.File.ReadAllBytes("lenna.jpg"));
         private WriteableBitmap? _prevRef;
+        private WriteableBitmap? _currentRef;
+        private WriteableBitmap? finalBitmap;
+
         private SKBitmap MySkBitmap => _mySkBitmap.Copy();
-        public IObservable<Bitmap?> DisplayInputImageObservable => Observable.Interval(TimeSpan.FromMilliseconds(10)).Select(_ => MySkBitmap)
-            .Select(img =>
+
+
+
+        async Task LoadNewImageAsync()
+        {
+            await Task.Run(() =>
             {
-                using var skImage = SKImage.FromBitmap(img);
+                using var skImage = SKImage.FromBitmap(MySkBitmap);
                 using var data = skImage.Encode(SKEncodedImageFormat.Jpeg, 100);
                 using var stream = data.AsStream();
                 var writeableBitmap = WriteableBitmap.Decode(stream);
-                img.Dispose();
+                MySkBitmap.Dispose();
 
 
-                if (_prevRef != writeableBitmap && _prevRef is not null)
+                if (_prevRef != FinalBitmap && _prevRef is not null)
                 {
                     _prevRef.Dispose();
                 }
 
-                _prevRef = writeableBitmap;
+                _prevRef = finalBitmap;
 
-                return writeableBitmap;
-            })
-            .Catch<Bitmap?, Exception>(e => { return Observable.Empty<Bitmap>(); });
+                finalBitmap = writeableBitmap;
+            });
+
+            this.RaisePropertyChanged(nameof(FinalBitmap));
+        }
+
+        public WriteableBitmap? FinalBitmap => finalBitmap;
     }
 }

--- a/app_resize_while_render/Views/MainWindow.axaml
+++ b/app_resize_while_render/Views/MainWindow.axaml
@@ -12,7 +12,7 @@
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 
-    <Image Source="{Binding DisplayInputImageObservable^}"
+    <Image Source="{Binding FinalBitmap}"
            Name="MyImage"
            Stretch="Fill" />
 


### PR DESCRIPTION
- use Task to load new image
- Don't bind to Image via ^ as the image Binding may not be updated while the Bitmap already get's disposed.